### PR TITLE
Add kagi as a search engine

### DIFF
--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -322,7 +322,7 @@
         const urlbarTooltip = "Quick Search Normal: Type a query and press Ctrl+Enter\n" +
                             "Quick Search Glance: Type a query and press Ctrl+Shift+Enter\n" +
                             "Prefixes: g: (Google), b: (Bing), d: (DuckDuckGo), e: (Ecosia), " + 
-                            "so: (Stack Overflow), gh: (GitHub), wiki: (Wikipedia)";
+                            "k: (Kagi), so: (Stack Overflow), gh: (GitHub), wiki: (Wikipedia)";
         try {
             urlbar.setAttribute("tooltip", urlbarTooltip);
             urlbar.setAttribute("title", urlbarTooltip);

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -131,6 +131,10 @@
                 prefix: 'e:',
                 url: 'https://www.ecosia.org/search?q='
             },
+            kagi: {
+                prefix: 'k:',
+                url: 'https://kagi.com/search?q='
+            },
             stackoverflow: {
                 prefix: 'so:',
                 url: 'https://stackoverflow.com/search?q='

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -210,6 +210,10 @@
             ecosia: {
                 prefix: 'e:',
                 url: 'https://www.ecosia.org/search?q='
+            },            
+            kagi: {
+                prefix: 'k:',
+                url: 'https://kagi.com/search?q='
             },
             stackoverflow: {
                 prefix: 'so:',


### PR DESCRIPTION
I'm a kagi user and while I know paid search engines aren't everyone's cup of tea, I think having the option is nice :)

I simply added it in your list of search engines, looks like this when searching with it using this mod:
![2025-06-16_21-52-54](https://github.com/user-attachments/assets/bbb19ac7-868b-4041-98d8-a9d174ee5260)
