### PR TITLE
Improve in Drag and Drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ https://github.com/user-attachments/assets/827215fc-e985-4f71-8646-6e3a6b7e624b
 - **Flexible positioning**: Top-right, top-left, center, bottom corners
 - **Resizable container**: Drag to resize, remembers your preferred size
 - **Smooth animations**: Configurable slide-in/out effects
+- **Drag and Drop**: Resize and change position easily with drag and drop 
 
 ### ⚡ **Advanced Functionality**
 - **Zen Glance Mode**: Launch searches in Zen Browser's Glance mode

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ All preferences are located under the `extensions.quicksearch.*` branch in `abou
   - Enable/disable slide-in/slide-out animations
 - `extensions.quicksearch.behavior.remember_size` (boolean, default: true)
   - Remember and restore container dimensions between sessions
+- `extensions.quicksearch.behavior.drag_resize_enabled` (boolean, default: true)
+  - Enable Resize and drag and drop.
 - `extensions.quicksearch.behavior.auto_focus` (boolean, default: true)
   - Automatically focus search input when Quick Search opens
 

--- a/preferences.json
+++ b/preferences.json
@@ -110,6 +110,14 @@
     "description": "Remember and restore the last used container dimensions"
   },
   {
+    "property": "extensions.quicksearch.behavior.drag_resize_enabled",
+    "label": "Enable Drag and Drop",
+    "type": "checkbox",
+    "placeholder": false,
+    "default": true,
+    "description": "Enable resize and change position of container with drag and drop"
+  },
+  {
     "property": "extensions.quicksearch.behavior.auto_focus",
     "label": "Auto Focus Search Bar",
     "type": "checkbox",

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -1155,6 +1155,7 @@
                 
                 // Save the new dimensions
                 saveContainerDimensions(container.offsetWidth, container.offsetHeight);
+                if (CONTAINER_POSITION == 'center') applyContainerPosition('center')
             }
         }
         

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -9,6 +9,8 @@
     const CONTEXT_MENU_ACCESS_KEY_PREF = "extensions.quicksearch.context_menu.access_key";
     const CONTAINER_POSITION_PREF = "extensions.quicksearch.container.position";
     const CONTAINER_THEME_PREF = "extensions.quicksearch.container.theme";
+    const CONTAINER_WIDTH_PREF = "extensions.quicksearch.container.width";
+    const CONTAINER_HEIGHT_PREF = "extensions.quicksearch.container.height";
     const BEHAVIOR_ANIMATION_ENABLED_PREF = "extensions.quicksearch.behavior.animation_enabled";
     const BEHAVIOR_REMEMBER_SIZE_PREF = "extensions.quicksearch.behavior.remember_size";
     const BEHAVIOR_AUTO_FOCUS_PREF = "extensions.quicksearch.behavior.auto_focus";
@@ -57,6 +59,8 @@
     const CONTEXT_MENU_ACCESS_KEY = getPref(CONTEXT_MENU_ACCESS_KEY_PREF, "Q");
     const CONTAINER_POSITION = getPref(CONTAINER_POSITION_PREF, "top-right");
     const CONTAINER_THEME = getPref(CONTAINER_THEME_PREF, "dark");
+    const CONTAINER_WIDTH = getPref(CONTAINER_WIDTH_PREF, 550);
+    const CONTAINER_HEIGHT = getPref(CONTAINER_HEIGHT_PREF, 300);
     const BEHAVIOR_ANIMATION_ENABLED = getPref(BEHAVIOR_ANIMATION_ENABLED_PREF, true);
     const BEHAVIOR_REMEMBER_SIZE = getPref(BEHAVIOR_REMEMBER_SIZE_PREF, true);
     const BEHAVIOR_AUTO_FOCUS = getPref(BEHAVIOR_AUTO_FOCUS_PREF, true);
@@ -897,16 +901,16 @@
     }
     
         function saveContainerDimensions(width, height) {
-        // Container dimensions are no longer saved - using fixed default size
-        console.log('QuickSearch: Container dimensions not saved (width/height settings removed)');
-    }
+          if (BEHAVIOR_REMEMBER_SIZE) {
+            setPref(CONTAINER_WIDTH_PREF, width)
+          setPref(CONTAINER_HEIGHT_PREF, height)
+          }
+        }
 
-        function loadContainerDimensions() {
-        // Use fixed default dimensions
-        const width = 550;
-        const height = 300;
-
+      function loadContainerDimensions() {
         const container = document.getElementById('quicksearch-container');
+        const width  = CONTAINER_WIDTH 
+        const height = CONTAINER_HEIGHT
         if (container) {
             container.style.width = `${width}px`;
             container.style.height = `${height}px`;

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -161,6 +161,15 @@
             'bottom-left': { bottom: '10px', left: '10px', top: 'auto', right: 'auto' }
         };
 
+        const resizeHandleStyles = {
+            'top-left': { top: 'auto', left: 'auto', right: '0', bottom: '0', transform: 'rotate(90deg)', cursor: 'se-resize' },
+            'center': { top: 'auto', left: 'auto', right: '0', bottom: '0', transform: 'rotate(90deg)', cursor: 'se-resize' },
+            'top-right': { top: 'auto', right: 'auto', left: '0', bottom: '0', transform: 'rotate(180deg)', cursor: 'sw-resize' },
+            'bottom-left': { bottom: 'auto', left: 'auto', top: '0', right: '0', transform: 'rotate(0deg)', cursor: 'ne-resize' },
+            'bottom-right': { bottom: 'auto', right: 'auto', top: '0', left: '0', transform: 'rotate(270deg)', cursor: 'nw-resize' },
+        };
+        
+        const currentResizeHandleStyles = resizeHandleStyles[position] || resizeHandleStyles['top-right'];
         const currentPosition = positions[position] || positions['top-right'];
 
         const css = `
@@ -301,18 +310,22 @@
             }
             
             #quicksearch-resizer {
-               position: absolute;
-               bottom: 0;
-               left: 0;
-               width: 0;
-               height: 0;
-               background:transparent;
-               border-style: solid;
-               border-width: 0 16px 16px 0;
-               border-color: transparent #fff transparent transparent;
-               cursor: sw-resize;
-               z-index: 10001;
-               transform: rotate(180deg);
+              position: absolute;
+              bottom: 0;
+              left: 0;
+              width: 0;
+              height: 0;
+              background:transparent;
+              border-style: solid;
+              border-width: 0 16px 16px 0;
+              border-color: transparent #fff transparent transparent;
+              z-index: 10001;
+              top: ${currentResizeHandleStyles.top};
+              right: ${currentResizeHandleStyles.right};
+              left: ${currentResizeHandleStyles.left};
+              bottom: ${currentResizeHandleStyles.bottom};
+              cursor: ${currentResizeHandleStyles.cursor};
+              transform: ${currentResizeHandleStyles.transform};
             }
 
             #quicksearch-engine-select-wrapper {
@@ -1012,8 +1025,8 @@
         function doResize(e) {
             if (!isResizing) return;
             
-            let width = startWidth - (e.clientX - startX);
-            let height = startHeight - (startY - e.clientY);
+            let width = startWidth + (e.clientX - startX) * (CONTAINER_POSITION.includes('right') ? -1 : 1);
+            let height = startHeight + (e.clientY - startY) * (CONTAINER_POSITION.includes('bottom') ? -1 : 1);
             
             // Enforce minimum dimensions
             width = Math.max(width, 200);

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -902,35 +902,38 @@
         const positions = {
             'top-right': { top: '10px', right: '10px', left: 'auto', bottom: 'auto' },
             'top-left': { top: '10px', left: '10px', right: 'auto', bottom: 'auto' },
-            'center': { top: '50%', left: '50%', right: 'auto', bottom: 'auto', transform: 'translate(-50%, -50%)' },
             'bottom-right': { bottom: '10px', right: '10px', top: 'auto', left: 'auto' },
             'bottom-left': { bottom: '10px', left: '10px', top: 'auto', right: 'auto' }
         };
 
         const targetPosition = positions[positionName] || positions['top-right'];
 
-        // Apply new properties to container
-        container.style.top = targetPosition.top;
-        container.style.right = targetPosition.right;
-        container.style.left = targetPosition.left;
-        container.style.bottom = targetPosition.bottom;
-        
         if (positionName === 'center') {
-            container.style.transform = targetPosition.transform;
-        } else {
-            container.style.removeProperty('transform');
-        }
+            // Calculate center position in pixels
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
+            const containerWidth = container.offsetWidth;
+            const containerHeight = container.offsetHeight;
 
+            const left = (windowWidth - containerWidth) / 2;
+            const top = (windowHeight - containerHeight) / 2;
+
+            container.style.top = `${top}px`;
+            container.style.left = `${left}px`;
+            container.style.right = 'auto';
+            container.style.bottom = 'auto';
+        } else {
+          for (const property in targetPosition) {
+              container.style[property] = targetPosition[property];
+          }
+        }
+        
         // Apply styles to resizer element based on new position
         if (resizer) {
             const resizerStyles = resize_habdle_styles[positionName] || resize_habdle_styles['top-right'];
-            resizer.style.inset = 'auto';
-            resizer.style.top = resizerStyles.top;
-            resizer.style.right = resizerStyles.right;
-            resizer.style.left = resizerStyles.left;
-            resizer.style.bottom = resizerStyles.bottom;
-            resizer.style.cursor = resizerStyles.cursor;
-            resizer.style.transform = resizerStyles.transform;
+            for (const property in resizerStyles) {
+                 resizer.style[property] = resizerStyles[property];
+             }
         }
     }
 
@@ -1187,11 +1190,6 @@
             initialContainerX = rect.left; // This is the computed pixel value
             initialContainerY = rect.top; // This is the computed pixel value
 
-            // Remove existing positioning properties to allow direct top/left manipulation
-            container.style.removeProperty('right');
-            container.style.removeProperty('bottom');
-            container.style.removeProperty('transform');
-            
             // Set position to current pixel values to prevent jump when transform is removed
             container.style.left = `${initialContainerX}px`;
             container.style.top = `${initialContainerY}px`;

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -235,7 +235,17 @@
                 user-select: none;
                 -moz-user-select: none;
                 gap: 8px;
+                position: relative;
+            }
+
+            #quicksearch-drag-handle {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
                 cursor: grab;
+                z-index: 0;
             }
 
             #quicksearch-header-title {
@@ -253,6 +263,7 @@
                 background-color: ${currentTheme.containerBg};
                 color: ${currentTheme.headerColor};
                 border-radius: 4px;
+                z-index: 1;
             }
             
             #quicksearch-browser-container {
@@ -289,6 +300,8 @@
                 box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
                 transition: background-color 0.2s, transform 0.2s;
                 flex-shrink: 0;
+                position: relative;
+                z-index: 1;
             }
             
             .quicksearch-close-button:hover {
@@ -317,6 +330,8 @@
               font-size: 14px;
               flex-grow: 1;
               min-width: 0;
+              max-width:140px;
+              z-index: 1;
             }
 
             #quicksearch-engine-select {
@@ -330,7 +345,6 @@
               color: ${currentTheme.headerColor};
               transition: background-color 0.2s;
               width: 100%;
-              max-width:140px;
               text-align: left;
               overflow: hidden;
               white-space: nowrap;
@@ -1009,6 +1023,9 @@
         const header = document.createElement('div');
         header.id = 'quicksearch-header';
 
+        const dragHandle = document.createElement('div');
+        dragHandle.id = 'quicksearch-drag-handle';
+
         const quicksearchEngineWrapper = document.createElement('div');
         quicksearchEngineWrapper.id = 'quicksearch-engine-select-wrapper';
 
@@ -1074,6 +1091,7 @@
             closeQuickSearch(container);
         };
 
+        header.appendChild(dragHandle);
         header.appendChild(quicksearchEngineWrapper);
         header.appendChild(closeButton);
 
@@ -1173,12 +1191,12 @@
             isDragging = false;
             document.removeEventListener('mousemove', doDrag);
             document.removeEventListener('mouseup', stopDrag);
-            header.style.cursor = 'grab'; // Reset cursor
+            dragHandle.style.cursor = 'grab'; // Reset cursor
 
             snapToClosestCorner(); 
         };
 
-        header.addEventListener('mousedown', function(e) {
+        dragHandle.addEventListener('mousedown', function(e) {
             // Only drag with left mouse button
             if (e.button !== 0) return; 
 
@@ -1194,7 +1212,7 @@
             container.style.left = `${initialContainerX}px`;
             container.style.top = `${initialContainerY}px`;
 
-            header.style.cursor = 'grabbing';
+            dragHandle.style.cursor = 'grabbing';
             document.addEventListener('mousemove', doDrag);
             document.addEventListener('mouseup', stopDrag);
 

--- a/quickSearch.uc.js
+++ b/quickSearch.uc.js
@@ -105,7 +105,7 @@
     }
 
     // Global definition for resizer styles to be used dynamically
-    const resize_habdle_styles = {
+    const resize_handle_styles = {
         'top-left': { top: 'auto', left: 'auto', right: '0', bottom: '0', transform: 'rotate(90deg)', cursor: 'se-resize' },
         'center': { top: 'auto', left: 'auto', right: '0', bottom: '0', transform: 'rotate(90deg)', cursor: 'se-resize' },
         'top-right': { top: 'auto', right: 'auto', left: '0', bottom: '0', transform: 'rotate(180deg)', cursor: 'sw-resize' },
@@ -167,28 +167,28 @@
         const css = `
             @keyframes quicksearchSlideIn {
                 0% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(0.8)' : 'translateY(-100%)'};
+                    transform: ${position === 'center' ? 'scale(0.8)' : 'translateY(-100%)'};
                     opacity: 0;
                 }
                 60% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(1.05)' : 'translateY(5%)'};
+                    transform: ${position === 'center' ? 'scale(1.05)' : 'translateY(5%)'};
                     opacity: 1;
                 }
                 80% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(0.98)' : 'translateY(-2%)'};
+                    transform: ${position === 'center' ? 'scale(0.98)' : 'translateY(-2%)'};
                 }
                 100% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(1)' : 'translateY(0)'};
+                    transform: ${position === 'center' ? 'scale(1)' : 'translateY(0)'};
                 }
             }
             
             @keyframes quicksearchSlideOut {
                 0% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(1)' : 'translateY(0)'};
+                    transform: ${position === 'center' ? 'scale(1)' : 'translateY(0)'};
                     opacity: 1;
                 }
                 100% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(0.8)' : 'translateY(-100%)'};
+                    transform: ${position === 'center' ? 'scale(0.8)' : 'translateY(-100%)'};
                     opacity: 0;
                 }
             }
@@ -912,8 +912,8 @@
             // Calculate center position in pixels
             const windowWidth = window.innerWidth;
             const windowHeight = window.innerHeight;
-            const containerWidth = container.offsetWidth;
-            const containerHeight = container.offsetHeight;
+            const containerWidth = container.offsetWidth || CONTAINER_WIDTH ;
+            const containerHeight = container.offsetHeight || CONTAINER_HEIGHT;
 
             const left = (windowWidth - containerWidth) / 2;
             const top = (windowHeight - containerHeight) / 2;
@@ -930,7 +930,7 @@
         
         // Apply styles to resizer element based on new position
         if (resizer) {
-            const resizerStyles = resize_habdle_styles[positionName] || resize_habdle_styles['top-right'];
+            const resizerStyles = resize_handle_styles[positionName] || resize_handle_styles['top-right'];
             for (const property in resizerStyles) {
                  resizer.style[property] = resizerStyles[property];
              }

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -683,56 +683,43 @@
 
     // Helper to apply position styles to container and resizer
      function applyContainerPosition(positionName) {
-        const container = document.getElementById('quicksearch-container');
+        let container = document.getElementById('quicksearch-container');
         const resizer = document.getElementById('quicksearch-resizer');
-        if (!container) return; // Should not happen if called correctly
-
         const positions = {
             'top-right': { top: '10px', right: '10px', left: 'auto', bottom: 'auto' },
             'top-left': { top: '10px', left: '10px', right: 'auto', bottom: 'auto' },
-            'center': { top: '50%', left: '50%', right: 'auto', bottom: 'auto', transform: 'translate(-50%, -50%)' },
             'bottom-right': { bottom: '10px', right: '10px', top: 'auto', left: 'auto' },
             'bottom-left': { bottom: '10px', left: '10px', top: 'auto', right: 'auto' }
         };
 
         const targetPosition = positions[positionName] || positions['top-right'];
 
-        // Clear all conflicting properties first to ensure new ones take effect cleanly
-        container.style.removeProperty('top');
-        container.style.removeProperty('right');
-        container.style.removeProperty('left');
-        container.style.removeProperty('bottom');
-        container.style.removeProperty('transform');
+        if (positionName === 'center') {
+            // Calculate center position in pixels
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
+            const containerWidth = container.offsetWidth;
+            const containerHeight = container.offsetHeight;
 
-        // Apply new properties to container
-        container.style.top = targetPosition.top;
-        container.style.right = targetPosition.right;
-        container.style.left = targetPosition.left;
-        container.style.bottom = targetPosition.bottom;
-        
-        if (targetPosition.transform) {
-            container.style.transform = targetPosition.transform;
+            const left = (windowWidth - containerWidth) / 2;
+            const top = (windowHeight - containerHeight) / 2;
+
+            container.style.top = `${top}px`;
+            container.style.left = `${left}px`;
+            container.style.right = 'auto';
+            container.style.bottom = 'auto';
         } else {
-            container.style.removeProperty('transform'); // Ensure transform is removed if not centered
+          for (const property in targetPosition) {
+              container.style[property] = targetPosition[property];
+          }
         }
-
+        
         // Apply styles to resizer element based on new position
         if (resizer) {
-            const resizerStyles = resize_handle_styles[positionName] || resize_handle_styles['top-right'];
-            // Clear all conflicting properties first for resizer too
-            resizer.style.removeProperty('top');
-            resizer.style.removeProperty('right');
-            resizer.style.removeProperty('left');
-            resizer.style.removeProperty('bottom');
-            resizer.style.removeProperty('cursor');
-            resizer.style.removeProperty('transform');
-
-            resizer.style.top = resizerStyles.top;
-            resizer.style.right = resizerStyles.right;
-            resizer.style.left = resizerStyles.left;
-            resizer.style.bottom = resizerStyles.bottom;
-            resizer.style.cursor = resizerStyles.cursor;
-            resizer.style.transform = resizerStyles.transform;
+            const resizerStyles = resize_habdle_styles[positionName] || resize_habdle_styles['top-right'];
+            for (const property in resizerStyles) {
+                 resizer.style[property] = resizerStyles[property];
+             }
         }
     }
 
@@ -1015,11 +1002,6 @@
             initialContainerX = rect.left; // This is the computed pixel value
             initialContainerY = rect.top; // This is the computed pixel value
 
-            // Remove existing positioning properties to allow direct top/left manipulation
-            container.style.removeProperty('right');
-            container.style.removeProperty('bottom');
-            container.style.removeProperty('transform');
-            
             // Set position to current pixel values to prevent jump when transform is removed
             container.style.left = `${initialContainerX}px`;
             container.style.top = `${initialContainerY}px`;

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -238,7 +238,17 @@
                 align-items: center;
                 min-height: 56px;
                 box-sizing: border-box;
+                position: relative;
+            }
+
+            #quicksearch-drag-handle {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
                 cursor: grab;
+                z-index: 0;
             }
             
             #quicksearch-searchbar {
@@ -252,6 +262,8 @@
                 color: ${currentTheme.textColor};
                 outline: none;
                 transition: background-color 0.2s;
+                position: relative;
+                z-index: 1;
             }
             
             #quicksearch-searchbar:focus {
@@ -298,6 +310,8 @@
                 cursor: pointer;
                 box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
                 transition: background-color 0.2s, transform 0.2s;
+                position: relative;
+                z-index: 1;
             }
             
             .quicksearch-close-button:hover {
@@ -324,6 +338,7 @@
               display: inline-block;
               min-width: 150px;
               font-size: 14px;
+              z-index: 1;
             }
 
             #quicksearch-engine-select {
@@ -786,6 +801,9 @@
         const searchBarContainer = document.createElement('div');
         searchBarContainer.id = 'quicksearch-searchbar-container';
         
+        const dragHandle = document.createElement('div');
+        dragHandle.id = 'quicksearch-drag-handle';
+
         const searchBar = document.createElement('input');
         searchBar.id = 'quicksearch-searchbar';
         searchBar.type = 'text';
@@ -871,6 +889,7 @@
             }
         });
         
+        searchBarContainer.appendChild(dragHandle);
         searchBarContainer.appendChild(searchBar);
         searchBarContainer.appendChild(quicksearchEngineWrapper);
         searchBarContainer.appendChild(closeButton);
@@ -985,12 +1004,12 @@
             isDragging = false;
             document.removeEventListener('mousemove', doDrag);
             document.removeEventListener('mouseup', stopDrag);
-            searchBarContainer.style.cursor = 'grab'; // Reset cursor
+            dragHandle.style.cursor = 'grab'; // Reset cursor
 
             snapToClosestCorner();
         };
 
-        searchBarContainer.addEventListener('mousedown', function(e) {
+        dragHandle.addEventListener('mousedown', function(e) {
             // Only drag with left mouse button
             if (e.button !== 0) return; 
 
@@ -1006,7 +1025,7 @@
             container.style.left = `${initialContainerX}px`;
             container.style.top = `${initialContainerY}px`;
 
-            searchBarContainer.style.cursor = 'grabbing';
+            dragHandle.style.cursor = 'grabbing';
             document.addEventListener('mousemove', doDrag);
             document.addEventListener('mouseup', stopDrag);
 

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -741,36 +741,42 @@
     // Function to snap container to the closest corner or center
     function snapToClosestCorner() {
         const container = document.getElementById('quicksearch-container');
-        if (!container) return;
-
         const rect = container.getBoundingClientRect();
         const currentX = rect.left;
         const currentY = rect.top;
         const containerWidth = rect.width;
         const containerHeight = rect.height;
 
-        const snapPoints = {
-            'top-left': { x: 10, y: 10 },
-            'top-right': { x: window.innerWidth - containerWidth - 10, y: 10 },
-            'center': { x: (window.innerWidth - containerWidth) / 2, y: (window.innerHeight - containerHeight) / 2, transformed: true },
-            'bottom-left': { x: 10, y: window.innerHeight - containerHeight - 10 },
-            'bottom-right': { x: window.innerWidth - containerWidth - 10, y: window.innerHeight - containerHeight - 10 }
+        const snapPositions = {
+            'top-left': { top: '10px', left: '10px' },
+            'top-right': { top: '10px', right: '10px' },
+            'center': { top: '50%', left: '50%' },
+            'bottom-left': { bottom: '10px', left: '10px' },
+            'bottom-right': { bottom: '10px', right: '10px' }
         };
 
         let closestPointName = '';
         let minDistance = Infinity;
 
-        for (const name in snapPoints) {
-            const p = snapPoints[name];
-            let targetX = p.x;
-            let targetY = p.y;
+        for (const name in snapPositions) {
+            const p = snapPositions[name];
+            let targetX, targetY;
 
-            // If a transform (like translate(-50%,-50%)) is applied,
-            // the CSS `left`/`top` values (targetX, targetY) would result in a *different* effective
-            // top-left pixel position. Adjust targetX/Y for distance calculation to reflect this.
-            if (p.transformed) { // Only 'center' has this property in our setup
-                targetX -= containerWidth / 2;
-                targetY -= containerHeight / 2;
+            if (name === 'center') {
+              targetX = (window.innerWidth / 2) - (containerWidth / 2);
+              targetY = (window.innerHeight / 2) - (containerHeight / 2);
+            } else {
+              if (p.left) {
+                  targetX = parseInt(p.left, 10);
+              } else if (p.right) {
+                  targetX = window.innerWidth - containerWidth - parseInt(p.right, 10);
+              }
+
+              if (p.top) {
+                  targetY = parseInt(p.top, 10);
+              } else if (p.bottom) {
+                  targetY = window.innerHeight - containerHeight - parseInt(p.bottom, 10);
+              }
             }
 
             const distance = Math.sqrt(Math.pow(currentX - targetX, 2) + Math.pow(currentY - targetY, 2));
@@ -780,9 +786,9 @@
                 closestPointName = name;
             }
         }
-        CONTAINER_POSITION = closestPointName; 
-        applyContainerPosition(CONTAINER_POSITION); 
-        setPref(CONTAINER_POSITION_PREF, CONTAINER_POSITION); 
+        applyContainerPosition(closestPointName);
+        CONTAINER_POSITION = closestPointName;
+        setPref(CONTAINER_POSITION_PREF, closestPointName);
     }
 
     // Create and initialize the search container

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -175,28 +175,28 @@
         const css = `
             @keyframes quicksearchSlideIn {
                 0% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(0.8)' : 'translateY(-100%)'};
+                    transform: ${position === 'center' ? 'scale(0.8)' : 'translateY(-100%)'};
                     opacity: 0;
                 }
                 60% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(1.05)' : 'translateY(5%)'};
+                    transform: ${position === 'center' ? 'scale(1.05)' : 'translateY(5%)'};
                     opacity: 1;
                 }
                 80% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(0.98)' : 'translateY(-2%)'};
+                    transform: ${position === 'center' ? 'scale(0.98)' : 'translateY(-2%)'};
                 }
                 100% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(1)' : 'translateY(0)'};
+                    transform: ${position === 'center' ? 'scale(1)' : 'translateY(0)'};
                 }
             }
             
             @keyframes quicksearchSlideOut {
                 0% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(1)' : 'translateY(0)'};
+                    transform: ${position === 'center' ? 'scale(1)' : 'translateY(0)'};
                     opacity: 1;
                 }
                 100% {
-                    transform: ${position === 'center' ? 'translate(-50%, -50%) scale(0.8)' : 'translateY(-100%)'};
+                    transform: ${position === 'center' ? 'scale(0.8)' : 'translateY(-100%)'};
                     opacity: 0;
                 }
             }
@@ -698,8 +698,8 @@
             // Calculate center position in pixels
             const windowWidth = window.innerWidth;
             const windowHeight = window.innerHeight;
-            const containerWidth = container.offsetWidth;
-            const containerHeight = container.offsetHeight;
+            const containerWidth = container.offsetWidth || CONTAINER_WIDTH ;
+            const containerHeight = container.offsetHeight || CONTAINER_HEIGHT;
 
             const left = (windowWidth - containerWidth) / 2;
             const top = (windowHeight - containerHeight) / 2;
@@ -716,7 +716,7 @@
         
         // Apply styles to resizer element based on new position
         if (resizer) {
-            const resizerStyles = resize_habdle_styles[positionName] || resize_habdle_styles['top-right'];
+            const resizerStyles = resize_handle_styles[positionName] || resize_handle_styles['top-right'];
             for (const property in resizerStyles) {
                  resizer.style[property] = resizerStyles[property];
              }

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -9,6 +9,8 @@
     const CONTEXT_MENU_ACCESS_KEY_PREF = "extensions.quicksearch.context_menu.access_key";
     const CONTAINER_POSITION_PREF = "extensions.quicksearch.container.position";
     const CONTAINER_THEME_PREF = "extensions.quicksearch.container.theme";
+    const CONTAINER_WIDTH_PREF = "extensions.quicksearch.container.width";
+    const CONTAINER_HEIGHT_PREF = "extensions.quicksearch.container.height";
     const BEHAVIOR_ANIMATION_ENABLED_PREF = "extensions.quicksearch.behavior.animation_enabled";
     const BEHAVIOR_REMEMBER_SIZE_PREF = "extensions.quicksearch.behavior.remember_size";
     const BEHAVIOR_AUTO_FOCUS_PREF = "extensions.quicksearch.behavior.auto_focus";
@@ -57,6 +59,8 @@
     const CONTEXT_MENU_ACCESS_KEY = getPref(CONTEXT_MENU_ACCESS_KEY_PREF, "Q");
     const CONTAINER_POSITION = getPref(CONTAINER_POSITION_PREF, "top-right");
     const CONTAINER_THEME = getPref(CONTAINER_THEME_PREF, "dark");
+    const CONTAINER_WIDTH = getPref(CONTAINER_WIDTH_PREF, 550);
+    const CONTAINER_HEIGHT = getPref(CONTAINER_HEIGHT_PREF, 300);
     const BEHAVIOR_ANIMATION_ENABLED = getPref(BEHAVIOR_ANIMATION_ENABLED_PREF, true);
     const BEHAVIOR_REMEMBER_SIZE = getPref(BEHAVIOR_REMEMBER_SIZE_PREF, true);
     const BEHAVIOR_AUTO_FOCUS = getPref(BEHAVIOR_AUTO_FOCUS_PREF, true);
@@ -681,16 +685,16 @@
     }
 
     function saveContainerDimensions(width, height) {
-        // Container dimensions are no longer saved - using fixed default size
-        console.log('QuickSearch NoBar: Container dimensions not saved (width/height settings removed)');
+        if (BEHAVIOR_REMEMBER_SIZE) {
+            setPref(CONTAINER_WIDTH_PREF, width)
+            setPref(CONTAINER_HEIGHT_PREF, height)
+        }
     }
 
     function loadContainerDimensions() {
-        // Use fixed default dimensions
-        const width = 550;
-        const height = 300;
-
         const container = document.getElementById('quicksearch-container');
+        const width  = CONTAINER_WIDTH 
+        const height = CONTAINER_HEIGHT
         if (container) {
             container.style.width = `${width}px`;
             container.style.height = `${height}px`;

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -743,36 +743,42 @@
     // Function to snap container to the closest corner or center
     function snapToClosestCorner() {
         const container = document.getElementById('quicksearch-container');
-        if (!container) return;
-
         const rect = container.getBoundingClientRect();
         const currentX = rect.left;
         const currentY = rect.top;
         const containerWidth = rect.width;
         const containerHeight = rect.height;
 
-        const snapPoints = {
-            'top-left': { x: 10, y: 10 },
-            'top-right': { x: window.innerWidth - containerWidth - 10, y: 10 },
-            'center': { x: (window.innerWidth - containerWidth) / 2, y: (window.innerHeight - containerHeight) / 2, transformed: true },
-            'bottom-left': { x: 10, y: window.innerHeight - containerHeight - 10 },
-            'bottom-right': { x: window.innerWidth - containerWidth - 10, y: window.innerHeight - containerHeight - 10 }
+        const snapPositions = {
+            'top-left': { top: '10px', left: '10px' },
+            'top-right': { top: '10px', right: '10px' },
+            'center': { top: '50%', left: '50%' },
+            'bottom-left': { bottom: '10px', left: '10px' },
+            'bottom-right': { bottom: '10px', right: '10px' }
         };
 
         let closestPointName = '';
         let minDistance = Infinity;
 
-        for (const name in snapPoints) {
-            const p = snapPoints[name];
-            let targetX = p.x;
-            let targetY = p.y;
+        for (const name in snapPositions) {
+            const p = snapPositions[name];
+            let targetX, targetY;
 
-            // If a transform (like translate(-50%,-50%)) is applied,
-            // the CSS `left`/`top` values (targetX, targetY) would result in a *different* effective
-            // top-left pixel position. Adjust targetX/Y for distance calculation to reflect this.
-            if (p.transformed) { // Only 'center' has this property in our setup
-                targetX -= containerWidth / 2;
-                targetY -= containerHeight / 2;
+            if (name === 'center') {
+              targetX = (window.innerWidth / 2) - (containerWidth / 2);
+              targetY = (window.innerHeight / 2) - (containerHeight / 2);
+            } else {
+              if (p.left) {
+                  targetX = parseInt(p.left, 10);
+              } else if (p.right) {
+                  targetX = window.innerWidth - containerWidth - parseInt(p.right, 10);
+              }
+
+              if (p.top) {
+                  targetY = parseInt(p.top, 10);
+              } else if (p.bottom) {
+                  targetY = window.innerHeight - containerHeight - parseInt(p.bottom, 10);
+              }
             }
 
             const distance = Math.sqrt(Math.pow(currentX - targetX, 2) + Math.pow(currentY - targetY, 2));
@@ -782,9 +788,9 @@
                 closestPointName = name;
             }
         }
-        CONTAINER_POSITION = closestPointName; 
-        applyContainerPosition(CONTAINER_POSITION); 
-        setPref(CONTAINER_POSITION_PREF, CONTAINER_POSITION); 
+        applyContainerPosition(closestPointName);
+        CONTAINER_POSITION = closestPointName;
+        setPref(CONTAINER_POSITION_PREF, closestPointName);
     }
 
     // Create and initialize the search container
@@ -966,8 +972,7 @@
                 
                 // Save the new dimensions
                 saveContainerDimensions(container.offsetWidth, container.offsetHeight);
-                // Snap to corner after resizing to adjust position if it shifted relative to page
-                snapToClosestCorner();
+                if (CONTAINER_POSITION == 'center') applyContainerPosition('center')
             }
         }
         

--- a/quickSearch_NoBar.uc.js
+++ b/quickSearch_NoBar.uc.js
@@ -168,6 +168,15 @@
             'bottom-left': { bottom: '10px', left: '10px', top: 'auto', right: 'auto' }
         };
 
+        const resizeHandleStyles = {
+            'top-left': { top: 'auto', left: 'auto', right: '0', bottom: '0', transform: 'rotate(90deg)', cursor: 'se-resize' },
+            'center': { top: 'auto', left: 'auto', right: '0', bottom: '0', transform: 'rotate(90deg)', cursor: 'se-resize' },
+            'top-right': { top: 'auto', right: 'auto', left: '0', bottom: '0', transform: 'rotate(180deg)', cursor: 'sw-resize' },
+            'bottom-left': { bottom: 'auto', left: 'auto', top: '0', right: '0', transform: 'rotate(0deg)', cursor: 'ne-resize' },
+            'bottom-right': { bottom: 'auto', right: 'auto', top: '0', left: '0', transform: 'rotate(270deg)', cursor: 'nw-resize' },
+        };
+        
+        const currentResizeHandleStyles = resizeHandleStyles[position] || resizeHandleStyles['top-right'];
         const currentPosition = positions[position] || positions['top-right'];
 
         const css = `
@@ -318,9 +327,13 @@
                 border-style: solid;
                 border-width: 0 16px 16px 0;
                 border-color: transparent #fff transparent transparent;
-                cursor: sw-resize;
                 z-index: 10001;
-                transform: rotate(180deg);
+                top: ${currentResizeHandleStyles.top};
+                right: ${currentResizeHandleStyles.right};
+                left: ${currentResizeHandleStyles.left};
+                bottom: ${currentResizeHandleStyles.bottom};
+                cursor: ${currentResizeHandleStyles.cursor};
+                transform: ${currentResizeHandleStyles.transform};
             }
 
             #quicksearch-engine-select-wrapper {
@@ -813,8 +826,8 @@
         function doResize(e) {
             if (!isResizing) return;
             
-            let width = startWidth - (e.clientX - startX);
-            let height = startHeight - (startY - e.clientY);
+            let width = startWidth + (e.clientX - startX) * (CONTAINER_POSITION.includes('right') ? -1 : 1);
+            let height = startHeight + (e.clientY - startY) * (CONTAINER_POSITION.includes('bottom') ? -1 : 1);
             
             // Enforce minimum dimensions
             width = Math.max(width, 200);


### PR DESCRIPTION
## Fixes:
- Better calculations while resizing in different position
- Proper position of resize handle based on container position

## New Features
- Drag and Drop to move the container (change it's potision)
- `extensions.quicksearch.behavior.remember_size` enabled
- Drag and drop can be disabled with `extensions.quicksearch.behavior.drag_resize_enabled`

## New preferences added
-  `extensions.quicksearch.behavior.drag_resize_enabled` to enable/disable drag and drop
- `extensions.quicksearch.container.width` 
- `extensions.quicksearch.container.height`

## Demo

https://github.com/user-attachments/assets/f47ce552-a36f-483e-b181-fd1aa41ddb21

